### PR TITLE
Added config option to enable logging of pwned password login rejections

### DIFF
--- a/Plugin.php
+++ b/Plugin.php
@@ -51,8 +51,8 @@ class Plugin extends PluginBase
             }
         });
         if (Config::get('winter.pwnedpasswords::enableRejectionLog', false)) {
-            Event::listen('pwnedpasswords.backend.login_rejected', function ($data) {
-                Log::info('Pwned password event listener called', $data);
+            Event::listen('pwnedpasswords.backend.login_rejected', function ($user) {
+                Log::info('Pwned password event listener called', $user->toArray());
             });
         }
 
@@ -76,14 +76,12 @@ class Plugin extends PluginBase
                     ) {
                         $validation = Validator::make(post(), ['password' => 'notpwned']);
                         if ($validation->fails()) {
-                            Event::fire('pwnedpasswords.backend.login_rejected', [[
-                                'time' => now()->toDateTimeString(),
-                                'action' => $action,
-                                'user_input' => post('login') ?? post('email') ?? '(unknown)',
-                            ]]);
                             // Force users to reset their password
                             if ($action === 'signin') {
                                 Event::listen('backend.user.login', function ($user) use ($controller) {
+                                    // Trigger event for login rejected due to pwned password
+                                    Event::fire('pwnedpasswords.backend.login_rejected', [$user]);
+
                                     // Make sure the user is not authenticated
                                     BackendAuth::logout();
 

--- a/Plugin.php
+++ b/Plugin.php
@@ -76,11 +76,11 @@ class Plugin extends PluginBase
                     ) {
                         $validation = Validator::make(post(), ['password' => 'notpwned']);
                         if ($validation->fails()) {
-                            Event::fire('pwnedpasswords.backend.login_rejected', [
+                            Event::fire('pwnedpasswords.backend.login_rejected', [[
                                 'time' => now()->toDateTimeString(),
                                 'action' => $action,
                                 'user_input' => post('login') ?? post('email') ?? '(unknown)',
-                            ]);
+                            ]]);
                             // Force users to reset their password
                             if ($action === 'signin') {
                                 Event::listen('backend.user.login', function ($user) use ($controller) {

--- a/Plugin.php
+++ b/Plugin.php
@@ -2,6 +2,7 @@
 
 use App;
 use Lang;
+use Log;
 use Event;
 use Flash;
 use Config;
@@ -49,6 +50,11 @@ class Plugin extends PluginBase
                 return Lang::get('winter.pwnedpasswords::lang.validation.notpwned');
             }
         });
+        if (Config::get('winter.pwnedpasswords::enableRejectionLog', false)) {
+            Event::listen('pwnedpasswords.backend.login_rejected', function ($data) {
+                Log::info('Pwned password event listener called', $data);
+            });
+        }
 
         // Register the `notpwned:min` rule
         Validator::extend('notpwned', NotPwned::class);
@@ -70,6 +76,11 @@ class Plugin extends PluginBase
                     ) {
                         $validation = Validator::make(post(), ['password' => 'notpwned']);
                         if ($validation->fails()) {
+                            Event::fire('pwnedpasswords.backend.login_rejected', [
+                                'time' => now()->toDateTimeString(),
+                                'action' => $action,
+                                'user_input' => post('login') ?? post('email') ?? '(unknown)',
+                            ]);
                             // Force users to reset their password
                             if ($action === 'signin') {
                                 Event::listen('backend.user.login', function ($user) use ($controller) {

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ To enforce this rule on the Backend authentication system, create a file at `con
 If you would also like to log rejected login attempts, you can enable the enableRejectionLog option in the same file
 
 ```php
-   'enableRejectionLog' => true,
+    'enableRejectionLog' => true,
 ```
 
 ## Overriding the validation message

--- a/README.md
+++ b/README.md
@@ -49,6 +49,12 @@ To enforce this rule on the Backend authentication system, create a file at `con
 ];
 ```
 
+
+If you would also like to log rejected login attempts, you can enable the enableRejectionLog option in the same file
+```php
+   'enableRejectionLog' => true,
+```
+
 ## Overriding the validation message
 
 To override the validation message, duplicate the plugin's `lang/en/lang.php` file to `project/lang/$locale/winter/pwnedpasswords/lang.php`.

--- a/README.md
+++ b/README.md
@@ -49,8 +49,8 @@ To enforce this rule on the Backend authentication system, create a file at `con
 ];
 ```
 
-
 If you would also like to log rejected login attempts, you can enable the enableRejectionLog option in the same file
+
 ```php
    'enableRejectionLog' => true,
 ```

--- a/config/config.php
+++ b/config/config.php
@@ -13,7 +13,18 @@
     | change their password.
     */
 
-    'enforceOnBackendUsers' => true,
-    'enableRejectionLog' => true
+    'enforceOnBackendUsers' => false,
+
+    /*
+    |--------------------------------------------------------------------------
+    | Enable logging for rejected backend logins
+    |--------------------------------------------------------------------------
+    |
+    | When enabled, any login attempt by a backend user with a compromised
+    | (pwned) password will trigger a log entry via the system logger. This
+    | is useful for auditing and monitoring potential security issues.
+    */
+
+    'enableRejectionLog' => false
 
 ];

--- a/config/config.php
+++ b/config/config.php
@@ -25,6 +25,6 @@
     | is useful for auditing and monitoring potential security issues.
     */
 
-    'enableRejectionLog' => false
+    'enableRejectionLog' => true,
 
 ];

--- a/config/config.php
+++ b/config/config.php
@@ -13,6 +13,7 @@
     | change their password.
     */
 
-    'enforceOnBackendUsers' => false,
+    'enforceOnBackendUsers' => true,
+    'enableRejectionLog' => true
 
 ];


### PR DESCRIPTION
<!--
Pull Requests without a descriptive title, thorough description, or tests will be closed.

Please include the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc. The more detail the better.

If documentation improvements are required, you are expected to make a simultaneous pull request to https://github.com/wintercms/docs to update the documentation
-->

## Related Issue
Fixes #2 

## Update 
- Add a config option to enable loggin for pwned password login rejections 

I tested updating the admin password with a known pwned password. The validation error correctly appears in the browser, but the rejection event is not logged in system.log. It seems like both Log and EventLog are not capturing the event as expected. Any thoughts or suggestions would be appreciated.

Before merging, I plan to set the config options to false by default.
